### PR TITLE
Fix command not found error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN \
   cd /tmp && \
   rm -rf /tmp/node-v* && \
   npm install -g npm && \
-  echo -e '\n# Node.js\nexport PATH="node_modules/.bin:$PATH"' >> /root/.bashrc
+  printf '\n# Node.js\nexport PATH="node_modules/.bin:$PATH"' >> /root/.bashrc
 
 # Define working directory.
 WORKDIR /data


### PR DESCRIPTION
`echo -e` does not behave correctly in the Dockerfile as it appends `-e` into the `.bashrc`. This causes a `bash: -e: command not found` error when running a container. By using `printf` we maintain the same functionality but remove this error.

Another option we could use is `/bin/echo -e`. This doesn't seem to create the error either. I have seen this in other Dockerfiles.

Commit 7a48133 caused this bug and by the comments of that commit, others seemed to be having this same issue.
